### PR TITLE
ルートパスをgroupsに変更した

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   devise_for :users
-  root "messages#index"
+  root "groups#index"
   resources :users, only: %i(edit update)
   resources :groups, only: %i(new create edit update) do
     resources :messages, only: %i(index create)


### PR DESCRIPTION
# WHAT
ルートパスをmessages#indexをgroups#indexに変更した。

# WHY
仮置きのルートパスから適正なルートにし、ビューで自分が所属しているグループを一覧でサイドバーに出すようにするため。