### PR TITLE
set_devise_to_rspec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,11 @@ require 'rspec/rails'
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f}
+  config.include Devise::Test::ControllerHelpers, type: :controller
+
+  config.include ControllerMacros, type: :controller
+
   config.include FactoryBot::Syntax::Methods
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,0 +1,6 @@
+module ControllerMacros
+  def login(user)
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+    sign_in user
+  end
+end


### PR DESCRIPTION
# WHAT
controller_macros.rbを作成し、log in メソッドを定義した。
rails_helper.rbに、deviseのコントローラのテスト用のモジュールと、ControllerMacrosを読み込む記述をした。

# WHY
rspecでdeviseを使えるようにするため。