### PR TITLE
Send messages asynchronously

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,46 @@
+$(function() {
+  function buildHTML(message){
+    var html = `<div class = 'chat-body'>
+                  <div class = 'chat-body--name' >
+                    <%= message.user_name %>
+                  </div>
+                  <div class = 'chat-body--time' >
+                    <%= message.created_at %>
+                  </div>
+                  <div class = 'chat-body--message' >
+                    <%= if message.body.present? %>
+                      <div class = 'chat-body--message__content' >
+                        <%= message.body %>
+                      </div>
+                    <%= image_tag message.image_url %>
+                    <% end %>
+                  </div>
+                </div>`
+  }
+
+  $('#new_message').on('submit', function(e) {
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+
+    .done(function(data) {
+      var html = buildHTML(data);
+      $('.main-content__chat-contents').append(html)
+      $('#message_body').val('')
+      $('.chat-body').animate ({
+        hight: "500px";
+      });
+    })
+    .fail(function(){
+      alert('error');
+    })
+  })
+});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -8,11 +8,16 @@ class MessagesController < ApplicationController
     @current_user_groups = GroupDecorator.decorate_collection(current_user_groups)
   end
 
+
   def create
     @message = @group.messages.new(message_params)
     @message.user = current_user
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html {redirect_to group_messages_path(@group)}
+        format.json
+      end
+      flash[:notice] = 'メッセージが送信されました'
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.id @message.id
+json.body @message.body
+json.image @message.image.url
+json.created_at @message.created_at


### PR DESCRIPTION
# WHAT
メッセージを非同期で送信できるようにした。
jbuilderファイルを作成してjson形式でメッセージを返すようにした。
createアクションでrespond_toを用いてhtmlとjsonに処理を分けるようにした。
# WHY
非同期にすることによってビューが毎回再描画されないようにするため。